### PR TITLE
Add confirmation dialog for stream/DLQ purge operations and changed stream purge icon

### DIFF
--- a/apps/web/app/(dashboard)/dlq/page.tsx
+++ b/apps/web/app/(dashboard)/dlq/page.tsx
@@ -27,16 +27,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import {
   Table,
   TableBody,
   TableCell,
@@ -511,27 +501,29 @@ export default function DlqPage() {
       </Dialog>
 
       {/* Purge Dialog */}
-      <AlertDialog open={purgeDialogOpen} onOpenChange={setPurgeDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Purge DLQ Stream</AlertDialogTitle>
-            <AlertDialogDescription>
+      <Dialog open={purgeDialogOpen} onOpenChange={setPurgeDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Purge DLQ Stream</DialogTitle>
+            <DialogDescription>
               Are you sure you want to purge all messages from{' '}
               <strong>{selectedStreamForPurge?.streamName}</strong>? This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPurgeDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
               onClick={handleConfirmPurge}
               disabled={purgeMutation.isPending}
-              className="bg-red-600 hover:bg-red-700"
             >
               {purgeMutation.isPending ? 'Purging...' : 'Purge All Messages'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web/app/(dashboard)/dlq/page.tsx
+++ b/apps/web/app/(dashboard)/dlq/page.tsx
@@ -27,6 +27,16 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
   Table,
   TableBody,
   TableCell,
@@ -501,29 +511,27 @@ export default function DlqPage() {
       </Dialog>
 
       {/* Purge Dialog */}
-      <Dialog open={purgeDialogOpen} onOpenChange={setPurgeDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Purge DLQ Stream</DialogTitle>
-            <DialogDescription>
+      <AlertDialog open={purgeDialogOpen} onOpenChange={setPurgeDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Purge DLQ Stream</AlertDialogTitle>
+            <AlertDialogDescription>
               Are you sure you want to purge all messages from{' '}
               <strong>{selectedStreamForPurge?.streamName}</strong>? This action cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setPurgeDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
               onClick={handleConfirmPurge}
               disabled={purgeMutation.isPending}
+              className="bg-red-600 hover:bg-red-700"
             >
               {purgeMutation.isPending ? 'Purging...' : 'Purge All Messages'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/web/app/(dashboard)/streams/[clusterId]/[name]/page.tsx
+++ b/apps/web/app/(dashboard)/streams/[clusterId]/[name]/page.tsx
@@ -12,6 +12,7 @@ import {
   MessageSquare,
   RefreshCw,
   Trash2,
+  Eraser,
   Edit,
   Play,
   AlertTriangle,
@@ -101,6 +102,7 @@ function StreamDetailContent() {
   const [messageSubject, setMessageSubject] = useState('');
   const [messageData, setMessageData] = useState('');
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showPurgeDialog, setShowPurgeDialog] = useState(false);
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [copiedMessageId, setCopiedMessageId] = useState<number | null>(null);
   const [expandedMessages, setExpandedMessages] = useState<Set<number>>(new Set());
@@ -439,10 +441,10 @@ function StreamDetailContent() {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => purgeMutation.mutate()}
+            onClick={() => setShowPurgeDialog(true)}
             disabled={purgeMutation.isPending}
           >
-            <RefreshCw className="h-4 w-4" />
+            <Eraser className="h-4 w-4" />
             Purge
           </Button>
           <Button
@@ -473,6 +475,30 @@ function StreamDetailContent() {
               className="bg-red-600 hover:bg-red-700"
             >
               {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Purge Confirmation Dialog */}
+      <AlertDialog open={showPurgeDialog} onOpenChange={setShowPurgeDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Purge Stream</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to purge all messages from stream &quot;{streamName}&quot;? This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                purgeMutation.mutate();
+                setShowPurgeDialog(false);
+              }}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              {purgeMutation.isPending ? 'Purging...' : 'Purge'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/app/(dashboard)/streams/[clusterId]/[name]/page.tsx
+++ b/apps/web/app/(dashboard)/streams/[clusterId]/[name]/page.tsx
@@ -481,28 +481,31 @@ function StreamDetailContent() {
       </AlertDialog>
 
       {/* Purge Confirmation Dialog */}
-      <AlertDialog open={showPurgeDialog} onOpenChange={setShowPurgeDialog}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Purge Stream</AlertDialogTitle>
-            <AlertDialogDescription>
+      <Dialog open={showPurgeDialog} onOpenChange={setShowPurgeDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Purge Stream</DialogTitle>
+            <DialogDescription>
               Are you sure you want to purge all messages from stream &quot;{streamName}&quot;? This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowPurgeDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
               onClick={() => {
                 purgeMutation.mutate();
                 setShowPurgeDialog(false);
               }}
-              className="bg-red-600 hover:bg-red-700"
+              disabled={purgeMutation.isPending}
             >
               {purgeMutation.isPending ? 'Purging...' : 'Purge'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Edit Stream Dialog */}
       <CreateStreamDialog


### PR DESCRIPTION
Fixes #2

## Summary
- Purging a stream previously fired `purgeMutation.mutate()` immediately on click, with no confirmation — unlike Delete on the same page, which already gates behind a confirmation dialog. Adds a confirmation dialog before purging a stream.
- Reuses the existing `Dialog` + destructive-button pattern already used for DLQ purge confirmation
- Swaps the purge button's icon from `RefreshCw` (reads as a safe refresh action) to `Eraser`, so it's visually distinct from actual refresh controls on the page.